### PR TITLE
Adding make_column_transformer

### DIFF
--- a/searchgrid.py
+++ b/searchgrid.py
@@ -176,10 +176,10 @@ def _name_steps(steps, default='alt'):
 
 def _name_of_estimator(estimator):
     if isinstance(estimator, tuple):
-        # tuples comes from ColumnTransformers. At the moment,
-        # sklearn accepts both (estimator, 'name') and ('name', estimator)
+        # tuples comes from ColumnTransformers. At the moment, sklearn accepts
+        # both (estimator, list_of_columns) and (list_of_columns, estimator)
         tuple_types = {type(tuple_entry) for tuple_entry in estimator}
-        tuple_types.discard(str)
+        tuple_types.discard(list)
         estimator_type = tuple_types.pop()
     else:
         estimator_type = type(estimator)
@@ -281,7 +281,7 @@ def make_column_transformer(*transformers, **kwargs):
     steps
         Each step is specified as one of:
 
-        * an (estimator, column_name) or (column_name, estimator) tuple
+        * an (estimator, [column_names]) or ([column_names], estimator) tuple
         * None (meaning no features)
         * a list of the above, indicating that a grid search should alternate
           over the estimators (or None) in the list

--- a/test_searchgrid.py
+++ b/test_searchgrid.py
@@ -114,15 +114,15 @@ def test_make_pipeline():
 
 
 def test_make_column_transformer():
-    t1 = (SelectKBest(), 'column1')
-    t2 = (SelectKBest(), 'column2')
-    t3 = (SelectKBest(), 'column3')
-    t4 = (SelectKBest(), 'column4')
-    t5 = (SelectPercentile(), 'column5')
-    t6 = (SelectKBest(), 'column6')
-    t7 = (SelectKBest(), 'column7')
-    t8 = (SelectKBest(), 'column8')
-    t9 = (SelectPercentile(), 'column9')
+    t1 = (SelectKBest(), ['column1'])
+    t2 = (SelectKBest(), ['column2a', 'column2b'])
+    t3 = (SelectKBest(), ['column3'])
+    t4 = (SelectKBest(), ['column4'])
+    t5 = (SelectPercentile(), ['column5'])
+    t6 = (SelectKBest(), ['column6a', 'column6b'])
+    t7 = (SelectKBest(), ['column7'])
+    t8 = (SelectKBest(), ['column8'])
+    t9 = (SelectPercentile(), ['column9'])
 
     in_steps = [[t1, None],
                 [t2, t3],


### PR DESCRIPTION
Gave this issue a shot: https://github.com/jnothman/searchgrid/issues/13

ColumnTransformer breaks from Pipeline and FeatureUnion's pattern by accepting a list of (encoder, 'column_name') tuples, instead of just a list of encoders. As a result, one question for this PR is whether searchgrid should pass a transformer name to ColumnTransformer.transformer that only contains the encoder class name, or if it should also include the column name. To be consistent with make_pipeline and make_union, I chose only the encoder class name.

@jnothman I'd love any comments or suggestions!